### PR TITLE
Adjust Aspect Ratio

### DIFF
--- a/Arcade-Scramble.sv
+++ b/Arcade-Scramble.sv
@@ -190,8 +190,8 @@ assign FB_FORCE_BLANK = 0;
 
 wire [1:0] ar = status[20:19];
 
-assign VIDEO_ARX = (!ar) ? ((status[2] |landscape ) ? 8'd4 : 8'd3) : (ar - 1'd1);
-assign VIDEO_ARY = (!ar) ? ((status[2] |landscape ) ? 8'd3 : 8'd4) : 12'd0;
+assign VIDEO_ARX = (!ar) ? ((status[2] |landscape ) ? 8'd8 : 8'd7) : (ar - 1'd1);
+assign VIDEO_ARY = (!ar) ? ((status[2] |landscape ) ? 8'd7 : 8'd8) : 12'd0;
 
 `include "build_id.v" 
 localparam CONF_STR = {


### PR DESCRIPTION
Using the [MiSTer FPGA Aspect Ratio Calculator](https://morf77.pythonanywhere.com/ar) (originally developed by Kitrinx) I determined that the current core should have an 8:7 aspect ratio instead of a 4:3 aspect ratio. The end result is much better:

Current Core at 4:3 is too thin:
![scramble_4x3](https://user-images.githubusercontent.com/16388068/166399668-77a37da9-079a-4dfd-97b7-0ea001f0609f.png)
![scramble_3x4](https://user-images.githubusercontent.com/16388068/166399670-161f8381-1858-4f40-99ed-213d9353e16b.png)

Adjusted to 8:7 yields what looks to be much better results:
![scramble_8x7](https://user-images.githubusercontent.com/16388068/166399686-bb631952-4b67-489a-9fa2-543e843dc7e3.png)
![scramble_7x8](https://user-images.githubusercontent.com/16388068/166399688-25d56f07-7af2-49c7-b9b8-4728e721775c.png)

